### PR TITLE
Fix multiLineWrap line-construction

### DIFF
--- a/src/ImagickDemo/Tutorial/multiLineWrap.php
+++ b/src/ImagickDemo/Tutorial/multiLineWrap.php
@@ -30,16 +30,21 @@ class WordWrap
         $lines = array();
         $currentLine = '';
         foreach ($words as $word) {
-            $currentLine .= $word;
-            $possibleLine = $currentLine . ' '. $word;
-            //Check to see if we can add another word to this line
-            $metrics = $imagick->queryFontMetrics($draw, $currentLine);
+            if (strlen($currentLine) > 0) {
+                $possibleLine = $currentLine . ' '. $word;
+            } else {
+                $possibleLine = $word;
+            }
+            //If adding the next word would make the current line
+            //too long, place that line into the array
+            //and use the next word to start a new line.
+            $metrics = $imagick->queryFontMetrics($draw, $possibleLine);
             if ($metrics['textWidth'] >= $maxWidth) {
                 $lines[] = $currentLine;
                 $currentLine = $word;
             }
             else {
-                $currentLine .= ' ';
+                $currentLine = $possibleLine;
             }
             //Finally, update line height
             if ($metrics['textHeight'] > $lineHeight) {


### PR DESCRIPTION
* Test the length of `$possibleLine` for overflow, not the length of `$currentLine`.
* If `$possibleLine` doesn't overflow, it becomes the new `$currentLine`.
* Only insert a space before the next `$word` when appending to a non-empty line.